### PR TITLE
PBRify: add alpha support + fix layers

### DIFF
--- a/workflows/rtx_remix_pbrify_remix_workflow.png
+++ b/workflows/rtx_remix_pbrify_remix_workflow.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3271f47830b5e29f5d3ddc8cd1dc49609f457006b87d905209f85840827b5bad
-size 7618824
+oid sha256:fdb330e5d8aa440700366097fdf5862dcf93f4a830395c6dd30425edd3e1ad4b
+size 7776027


### PR DESCRIPTION
This adds alpha layer support from NightRaven's PR, and also fixes the upscale usda layer being deleted each time ComfyUI and the toolkit are restarted.